### PR TITLE
Handle varying IB API error signatures

### DIFF
--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -1,0 +1,18 @@
+import unittest
+
+from ibapi import comm
+
+
+class CommTestCase(unittest.TestCase):
+    def test_make_msg(self):
+        text = "ABCD"
+        try:
+            msg = comm.make_msg(0, False, text)
+        except TypeError:
+            msg = comm.make_msg(text)
+        assert isinstance(msg, (bytes, bytearray))
+        assert msg.endswith(text.encode())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add compat error handler supporting multiple IB API signatures
- centralize error logging and callback dispatch
- add backward-compatible test for updated `comm.make_msg` signature

## Testing
- `python -m py_compile atreyu_backtrader_api/ibstore.py tests/test_comm.py`
- `flake8 atreyu_backtrader_api/ibstore.py` *(fails: F401, E402, E302, ...)*
- `flake8 tests/test_comm.py`
- `pytest tests/test_comm.py`


------
https://chatgpt.com/codex/tasks/task_e_689773573a288322b7b55ef4b2e8b245