### PR TITLE
Ensure cash quantity is always set for cash contracts

### DIFF
--- a/atreyu_backtrader_api/ibbroker.py
+++ b/atreyu_backtrader_api/ibbroker.py
@@ -181,7 +181,13 @@ class IBOrder(OrderBase, ibapi.order.Order):
         # orders lacking this value with error 10289 ("You must set Cash
         # Quantity for this order"). Copy the total quantity into ``cashQty``
         # when the contract type is ``CASH`` to satisfy this requirement.
-        if getattr(getattr(self.data, 'tradecontract', None), 'secType', None) == 'CASH':
+        tradecontract = getattr(self.data, 'tradecontract', None)
+        secType = getattr(tradecontract, 'secType', None)
+        if secType is None:
+            contract = getattr(self.data, 'contract', None)
+            secType = getattr(contract, 'secType', None)
+
+        if secType == 'CASH':
             self.cashQty = self.totalQuantity
 
         # self.m_transmit = self.transmit


### PR DESCRIPTION
## Summary
- Ensure cashQty is populated for cash contracts even when `tradecontract` is unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5985e257c832284dc52a9cda117f8